### PR TITLE
Fix mypy error with testfixtures type annotations

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,3 +11,4 @@ python:
          - build
 sphinx:
   fail_on_warning: true
+  configuration: docs/conf.py

--- a/mypy.ini
+++ b/mypy.ini
@@ -15,6 +15,3 @@ ignore_missing_imports = True
 
 [mypy-docker.*]
 ignore_missing_imports = True
-
-[mypy-testfixtures.*]
-ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
             'pytest',
             'pytest-cov',
             'sybil',
-            'testfixtures',
+            'testfixtures>=9.2',
             'psycopg',
             'sqlalchemy',
         ],

--- a/tests/test_tcp.py
+++ b/tests/test_tcp.py
@@ -10,9 +10,8 @@ from testservices.tcp import wait_for_server
 class TestWaitForServer:
 
     def test_error_not_connection_refused(self):
-        with ShouldRaise() as s:
+        with ShouldRaise(socket.gaierror):
             wait_for_server(-1, '127.0.0.-1')
-        assert isinstance(s.raised, socket.error)
 
     def test_port_must_be_specified(self):
         with ShouldRaise(AssertionError('port may not be None')):


### PR DESCRIPTION
## Summary
- Updated mypy configuration to recognize testfixtures type annotations
- Added minimum version constraint for testfixtures (>=9.2)
- Fixed test to use specific exception type with ShouldRaise

🤖 Generated with [Claude Code](https://claude.com/claude-code)